### PR TITLE
Only instantiate new criteria definitions

### DIFF
--- a/engine/src/main/java/org/cafienne/cmmn/instance/PlanItemEntry.java
+++ b/engine/src/main/java/org/cafienne/cmmn/instance/PlanItemEntry.java
@@ -114,7 +114,7 @@ public class PlanItemEntry extends CriteriaListener<EntryCriterionDefinition, En
 
     @Override
     protected void migrateCriteria(ItemDefinition newItemDefinition, boolean skipLogic) {
-        migrateCriteria(newItemDefinition.getEntryCriteria(), skipLogic);
+        migrateCriteria(newItemDefinition.getEntryCriteria(), item.getPreviousItemDefinition().getEntryCriteria(), skipLogic);
         if (skipLogic) {
             return;
         }

--- a/engine/src/main/java/org/cafienne/cmmn/instance/PlanItemExit.java
+++ b/engine/src/main/java/org/cafienne/cmmn/instance/PlanItemExit.java
@@ -54,6 +54,6 @@ public class PlanItemExit extends CriteriaListener<ExitCriterionDefinition, Exit
 
     @Override
     protected void migrateCriteria(ItemDefinition newItemDefinition, boolean skipLogic) {
-        migrateCriteria(newItemDefinition.getExitCriteria(), skipLogic);
+        migrateCriteria(newItemDefinition.getExitCriteria(), item.getPreviousItemDefinition().getExitCriteria(), skipLogic);
     }
 }

--- a/engine/src/main/java/org/cafienne/cmmn/instance/PlanItemReactivation.java
+++ b/engine/src/main/java/org/cafienne/cmmn/instance/PlanItemReactivation.java
@@ -62,6 +62,6 @@ public class PlanItemReactivation extends CriteriaListener<ReactivateCriterionDe
 
     @Override
     protected void migrateCriteria(ItemDefinition newItemDefinition, boolean skipLogic) {
-        migrateCriteria(newItemDefinition.getReactivatingCriteria(), skipLogic);
+        migrateCriteria(newItemDefinition.getReactivatingCriteria(), item.getPreviousItemDefinition().getReactivatingCriteria(), skipLogic);
     }
 }

--- a/engine/src/main/java/org/cafienne/cmmn/instance/sentry/CriteriaListener.java
+++ b/engine/src/main/java/org/cafienne/cmmn/instance/sentry/CriteriaListener.java
@@ -91,7 +91,7 @@ public abstract class CriteriaListener<T extends CriterionDefinition, C extends 
 
     protected abstract void migrateCriteria(ItemDefinition newItemDefinition, boolean skipLogic);
 
-    protected void migrateCriteria(Collection<T> newDefinitions, boolean skipLogic) {
+    protected void migrateCriteria(Collection<T> newDefinitions, Collection<T> existingDefinitions, boolean skipLogic) {
         if (isDisconnected()) {
             addDebugInfo(() -> "Skipping " + logDescription + " criteria migration of " + item + " as they are disconnected");
             return;
@@ -106,11 +106,11 @@ public abstract class CriteriaListener<T extends CriterionDefinition, C extends 
         Collection<C> existingCriteria = new ArrayList<>(criteria);
 
         existingCriteria.forEach(criterion -> migrateCriterion(criterion, newDefinitions, skipLogic));
-        newDefinitions.stream().filter(this::notYetHasCriterion).forEach(this::addCriterion);
+        findNewDefinitions(newDefinitions, existingDefinitions).forEach(this::addCriterion);
     }
 
-    private boolean notYetHasCriterion(T definition) {
-        return this.criteria.stream().noneMatch(c -> c.getDefinition() == definition);
+    private Collection<T> findNewDefinitions(Collection<T> newDefinitions, Collection<T> existingDefinitions) {
+        return newDefinitions.stream().filter(newDefinition -> existingDefinitions.stream().allMatch(existingDefinition -> existingDefinition.differs(newDefinition))).toList();
     }
 
     private void migrateCriterion(C criterion, Collection<T> newDefinitions, boolean skipLogic) {


### PR DESCRIPTION
Instead of iterating existing instances, we now check the actual existing definition before creating a new criterion. Fixes #491